### PR TITLE
EPT: Fix profile viewer.

### DIFF
--- a/src/PointCloudEptGeometry.js
+++ b/src/PointCloudEptGeometry.js
@@ -140,6 +140,7 @@ export class PointCloudEptGeometryNode extends PointCloudTreeNode {
 				z);
 
 		this.id = PointCloudEptGeometryNode.IDCount++;
+		this.pcoGeometry = { "hierarchyStepSize": 1 };
 		this.geometry = null;
 		this.boundingBox = this.key.b;
 		this.tightBoundingBox = this.boundingBox;


### PR DESCRIPTION
There is probably a better way to do this, but this avoids a 'node.pcoGeometry undefined' error when viewing a 2D profile from an EPT source.